### PR TITLE
Fix bound: remove a redundant term

### DIFF
--- a/snn/core/network.py
+++ b/snn/core/network.py
@@ -439,7 +439,6 @@ class Network(object):
 
             KLdivTimes2 = (norm_post_variance+norm_params)/(tf.exp(2*log_prior_std)) + 2*nparams*log_prior_std - nparams - 2*sum_log_post_variance
             Bquad = KLdivTimes2/2 + tf.log(np.pi**2*effective_m/(6*self.deltaPAC)) \
-                                      + 2*np.log(self.log_prior_std_precision) \
                                       + 2*tf.log(jopt)
             B = tf.sqrt(Bquad/(2*(effective_m-1)))
 


### PR DESCRIPTION
I found an unnecessary term to compute the PAC-Bayes bound in `evaluate_SNN_accuracy` function.
I think that we don't need `2 * np.log(self.log_prior_std_precision)` because it is already used in the calculation of `2 * tf.log(jopt)`.

